### PR TITLE
Refactor: Move RoadRunner resources to dedicated package

### DIFF
--- a/TeamCode/src/main/java/RoadRunnerResourses/Drawing.java
+++ b/TeamCode/src/main/java/RoadRunnerResourses/Drawing.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode;
+package RoadRunnerResourses;
 
 import com.acmerobotics.dashboard.canvas.Canvas;
 import com.acmerobotics.roadrunner.Pose2d;

--- a/TeamCode/src/main/java/RoadRunnerResourses/Localizer.java
+++ b/TeamCode/src/main/java/RoadRunnerResourses/Localizer.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode;
+package RoadRunnerResourses;
 
 import com.acmerobotics.roadrunner.Pose2d;
 import com.acmerobotics.roadrunner.PoseVelocity2d;

--- a/TeamCode/src/main/java/RoadRunnerResourses/MecanumDrive.java
+++ b/TeamCode/src/main/java/RoadRunnerResourses/MecanumDrive.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode;
+package RoadRunnerResourses;
 
 import androidx.annotation.NonNull;
 
@@ -33,7 +33,6 @@ import com.acmerobotics.roadrunner.ftc.RawEncoder;
 import com.qualcomm.hardware.lynx.LynxModule;
 import com.qualcomm.hardware.rev.RevHubOrientationOnRobot;
 import com.qualcomm.robotcore.hardware.DcMotor;
-import com.qualcomm.robotcore.hardware.DcMotorSimple;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 import com.qualcomm.robotcore.hardware.IMU;

--- a/TeamCode/src/main/java/RoadRunnerResourses/OTOSLocalizer.java
+++ b/TeamCode/src/main/java/RoadRunnerResourses/OTOSLocalizer.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode;
+package RoadRunnerResourses;
 
 import com.acmerobotics.dashboard.config.Config;
 import com.acmerobotics.roadrunner.Pose2d;

--- a/TeamCode/src/main/java/RoadRunnerResourses/PinpointLocalizer.java
+++ b/TeamCode/src/main/java/RoadRunnerResourses/PinpointLocalizer.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode;
+package RoadRunnerResourses;
 
 import com.acmerobotics.dashboard.config.Config;
 import com.acmerobotics.roadrunner.Pose2d;

--- a/TeamCode/src/main/java/RoadRunnerResourses/TankDrive.java
+++ b/TeamCode/src/main/java/RoadRunnerResourses/TankDrive.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode;
+package RoadRunnerResourses;
 
 import androidx.annotation.NonNull;
 
@@ -43,7 +43,6 @@ import com.acmerobotics.roadrunner.ftc.RawEncoder;
 import com.qualcomm.hardware.lynx.LynxModule;
 import com.qualcomm.hardware.rev.RevHubOrientationOnRobot;
 import com.qualcomm.robotcore.hardware.DcMotor;
-import com.qualcomm.robotcore.hardware.DcMotorSimple;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 import com.qualcomm.robotcore.hardware.VoltageSensor;

--- a/TeamCode/src/main/java/RoadRunnerResourses/ThreeDeadWheelLocalizer.java
+++ b/TeamCode/src/main/java/RoadRunnerResourses/ThreeDeadWheelLocalizer.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode;
+package RoadRunnerResourses;
 
 import com.acmerobotics.dashboard.config.Config;
 import com.acmerobotics.roadrunner.DualNum;

--- a/TeamCode/src/main/java/RoadRunnerResourses/TwoDeadWheelLocalizer.java
+++ b/TeamCode/src/main/java/RoadRunnerResourses/TwoDeadWheelLocalizer.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode;
+package RoadRunnerResourses;
 
 import com.acmerobotics.dashboard.config.Config;
 import com.acmerobotics.roadrunner.DualNum;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/VariablePractice.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/VariablePractice.java
@@ -1,0 +1,25 @@
+package org.firstinspires.ftc.teamcode;
+
+import com.qualcomm.robotcore.eventloop.opmode.OpMode;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+
+@TeleOp
+public class VariablePractice extends OpMode {
+
+    @Override
+    public void init() {
+        int teamNumber = 22448;
+        double motorSpeed = 0.75;
+        boolean clawClosed = true;
+        String teamName = "The Rats";
+
+        telemetry.addData("team number", teamNumber );
+        telemetry.addData("motor speed", motorSpeed);
+        telemetry.addData("claw closed", clawClosed);
+        telemetry.addData("team name", teamName);
+    }
+
+    public void loop(){
+
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/LocalizationTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/LocalizationTest.java
@@ -8,9 +8,9 @@ import com.acmerobotics.roadrunner.PoseVelocity2d;
 import com.acmerobotics.roadrunner.Vector2d;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 
-import org.firstinspires.ftc.teamcode.Drawing;
-import org.firstinspires.ftc.teamcode.MecanumDrive;
-import org.firstinspires.ftc.teamcode.TankDrive;
+import RoadRunnerResourses.Drawing;
+import RoadRunnerResourses.MecanumDrive;
+import RoadRunnerResourses.TankDrive;
 
 public class LocalizationTest extends LinearOpMode {
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/ManualFeedbackTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/ManualFeedbackTuner.java
@@ -4,10 +4,10 @@ import com.acmerobotics.roadrunner.Pose2d;
 import com.acmerobotics.roadrunner.ftc.Actions;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 
-import org.firstinspires.ftc.teamcode.MecanumDrive;
-import org.firstinspires.ftc.teamcode.TankDrive;
-import org.firstinspires.ftc.teamcode.ThreeDeadWheelLocalizer;
-import org.firstinspires.ftc.teamcode.TwoDeadWheelLocalizer;
+import RoadRunnerResourses.MecanumDrive;
+import RoadRunnerResourses.TankDrive;
+import RoadRunnerResourses.ThreeDeadWheelLocalizer;
+import RoadRunnerResourses.TwoDeadWheelLocalizer;
 
 public final class ManualFeedbackTuner extends LinearOpMode {
     public static double DISTANCE = 64;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/SplineTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/SplineTest.java
@@ -5,8 +5,8 @@ import com.acmerobotics.roadrunner.Vector2d;
 import com.acmerobotics.roadrunner.ftc.Actions;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 
-import org.firstinspires.ftc.teamcode.MecanumDrive;
-import org.firstinspires.ftc.teamcode.TankDrive;
+import RoadRunnerResourses.MecanumDrive;
+import RoadRunnerResourses.TankDrive;
 
 public final class SplineTest extends LinearOpMode {
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/TuningOpModes.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/TuningOpModes.java
@@ -40,12 +40,12 @@ import com.qualcomm.robotcore.hardware.DcMotorSimple;
 
 import org.firstinspires.ftc.robotcore.external.navigation.UnnormalizedAngleUnit;
 import org.firstinspires.ftc.robotcore.internal.opmode.OpModeMeta;
-import org.firstinspires.ftc.teamcode.MecanumDrive;
-import org.firstinspires.ftc.teamcode.OTOSLocalizer;
-import org.firstinspires.ftc.teamcode.PinpointLocalizer;
-import org.firstinspires.ftc.teamcode.TankDrive;
-import org.firstinspires.ftc.teamcode.ThreeDeadWheelLocalizer;
-import org.firstinspires.ftc.teamcode.TwoDeadWheelLocalizer;
+import RoadRunnerResourses.MecanumDrive;
+import RoadRunnerResourses.OTOSLocalizer;
+import RoadRunnerResourses.PinpointLocalizer;
+import RoadRunnerResourses.TankDrive;
+import RoadRunnerResourses.ThreeDeadWheelLocalizer;
+import RoadRunnerResourses.TwoDeadWheelLocalizer;
 
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION
Moved RoadRunner-specific classes (Localizer, MecanumDrive, TankDrive, etc.) from the main `org.firstinspires.ftc.teamcode` package to a new `RoadRunnerResourses` package.

Updated import statements in tuning OpModes to reflect the new package structure.

Removed an unused import (`DcMotorSimple`) from `MecanumDrive.java` and `TankDrive.java`.

Add: Basic TeleOp for variable practice

Created a new OpMode `VariablePractice.java` that initializes and displays several variable types (int, double, boolean, String) using telemetry. This OpMode has an empty loop method.

Before issuing a pull request, please see the contributing page.
